### PR TITLE
Add Zero — browser-native multiplayer voxel sandbox

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -118,6 +118,11 @@ Efficient Dynamic Voxel Rendering
 - [https://github.com/mikelovesrobots/mmmm] A collection of everything needed to populate a city
 
 
+## Games
+
+- [Zero](https://0.space) :art: Browser-native multiplayer voxel sandbox. Three.js + custom Rust voxel engine (Dual Contouring) in WASM. Same engine ships to web, macOS, Windows, iOS.
+
+
 ## License
 
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](http://creativecommons.org/publicdomain/zero/1.0)


### PR DESCRIPTION
Adds [Zero](https://0.space) — a multiplayer voxel sandbox that runs in the browser.

- Built on three.js (TSL) with a custom voxel engine in Rust compiled to WASM
- Dual Contouring mesher
- Same engine also ships native to macOS, Windows, and iOS
- Live, free, no install, no signup

Proposed under a new **Games** section since the existing sections are oriented around editors/engines/utilities. If you'd rather place it inside an existing section (e.g. Tools), happy to adjust — or drop the new section if it's not a fit for the list's scope.